### PR TITLE
Add Docker/Postgres setup and EF Core integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DB_HOST=type_host_name			(IMPORTANT: if using docker container for database, put name of docker database service)
-DB_PORT=type_port				(Postresql standard is 5432)
+DB_PORT=type_port				(Our Postresql standard is 5433)
 DB_USER=type_username			(Sets username for database)
 DB_PASS=type_password			(Sets password for database)
 DB_NAME=type_db_name			(Sets name for database)

--- a/BetonBon.API/BetonBon.API.csproj
+++ b/BetonBon.API/BetonBon.API.csproj
@@ -7,7 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BetonBon.API/Program.cs
+++ b/BetonBon.API/Program.cs
@@ -33,6 +33,13 @@ namespace BetonBon.API
 
             var app = builder.Build();
 
+            // Auto-migrates new migrations on startup
+            using (var scope = app.Services.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<BetonBonDbContext>();
+                dbContext.Database.Migrate();
+            }
+
             // Configure the HTTP request pipeline.
             if (app.Environment.IsDevelopment())
             {

--- a/BetonBon.API/Program.cs
+++ b/BetonBon.API/Program.cs
@@ -1,5 +1,6 @@
-
+using BetonBon.Infrastructure;
 using DotNetEnv;
+using Microsoft.EntityFrameworkCore;
 
 namespace BetonBon.API
 {
@@ -16,6 +17,13 @@ namespace BetonBon.API
             var dbName = Environment.GetEnvironmentVariable("DB_NAME");
             var dbUser = Environment.GetEnvironmentVariable("DB_USER");
             var dbPass = Environment.GetEnvironmentVariable("DB_PASS");
+
+            var connectionString =
+                $"Host={dbHost};Port={dbPort};Database={dbName};Username={dbUser};Password={dbPass}";
+
+            builder.Services.AddDbContext<BetonBonDbContext>(options =>
+                options.UseNpgsql(connectionString)
+            );
 
             // Add services to the container.
             builder.Services.AddAuthorization();

--- a/BetonBon.Infrastructure/BetonBon.Infrastructure.csproj
+++ b/BetonBon.Infrastructure/BetonBon.Infrastructure.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BetonBon.Application\BetonBon.Application.csproj" />
     <ProjectReference Include="..\BetonBon.Domain\BetonBon.Domain.csproj" />
     <ProjectReference Include="..\BetonBon.Shared\BetonBon.Shared.csproj" />

--- a/BetonBon.Infrastructure/BetonBonDbContext.cs
+++ b/BetonBon.Infrastructure/BetonBonDbContext.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace BetonBon.Infrastructure
+{
+    public class BetonBonDbContext(DbContextOptions<BetonBonDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/BetonBon.slnx
+++ b/BetonBon.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Solution Items/">
     <File Path=".env" />
     <File Path=".env.example" />
+    <File Path="docker-compose.dev.yml" />
   </Folder>
   <Folder Name="/Testing/">
     <Project Path="BetonBon.Application.Tests/BetonBon.Application.Tests.csproj" Id="75c6a9b7-3648-4964-9a3e-67d6c87744a8" />

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+# Docker compose used for local testing/hosting
+# Only spins up a database container, API and Client runs through IDE
+
+name: betonbon-dev
+
+services:
+  db:
+    image: postgres:18-alpine
+    container_name: betonbon-postgres
+    restart: always
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_DB: ${DB_NAME}
+    ports:
+      - "5433:5433"
+    volumes:
+      - pgdata_local:/var/lib/postgresql/data
+
+volumes:
+  pgdata_local:  


### PR DESCRIPTION
Add Docker/Postgres setup and EF Core integration

Added docker-compose.dev.yml for local Postgres (port 5433). Updated .env.example to reflect new port. Integrated Entity Framework Core with BetonBonDbContext and registered it in Program.cs. Added necessary NuGet packages to BetonBon.API and BetonBon.Infrastructure. Included docker-compose.dev.yml in solution items.